### PR TITLE
Change incorrect json key of creator to created_by

### DIFF
--- a/lib/core/channel/base/base_channel.dart
+++ b/lib/core/channel/base/base_channel.dart
@@ -77,6 +77,7 @@ class BaseChannel implements Cacheable {
   String? coverUrl;
 
   /// User who creates this channel
+  @JsonKey(name: 'created_by')
   User? creator;
 
   /// timestamp when this channel is created

--- a/lib/core/channel/group/group_channel.g.dart
+++ b/lib/core/channel/group/group_channel.g.dart
@@ -56,9 +56,9 @@ GroupChannel _$GroupChannelFromJson(Map<String, dynamic> json) {
     channelUrl: json['channel_url'] as String,
     name: json['name'] as String?,
     coverUrl: json['cover_url'] as String?,
-    creator: json['creator'] == null
+    creator: json['created_by'] == null
         ? null
-        : User.fromJson(json['creator'] as Map<String, dynamic>),
+        : User.fromJson(json['created_by'] as Map<String, dynamic>),
     createdAt: json['created_at'] as int?,
     data: json['data'] as String?,
     customType: json['custom_type'] as String?,
@@ -72,7 +72,7 @@ Map<String, dynamic> _$GroupChannelToJson(GroupChannel instance) =>
       'channel_url': instance.channelUrl,
       'name': instance.name,
       'cover_url': instance.coverUrl,
-      'creator': instance.creator?.toJson(),
+      'created_by': instance.creator?.toJson(),
       'created_at': instance.createdAt,
       'data': instance.data,
       'custom_type': instance.customType,

--- a/lib/core/channel/open/open_channel.g.dart
+++ b/lib/core/channel/open/open_channel.g.dart
@@ -16,9 +16,9 @@ OpenChannel _$OpenChannelFromJson(Map<String, dynamic> json) {
     channelUrl: json['channel_url'] as String,
     name: json['name'] as String?,
     coverUrl: json['cover_url'] as String?,
-    creator: json['creator'] == null
+    creator: json['created_by'] == null
         ? null
-        : User.fromJson(json['creator'] as Map<String, dynamic>),
+        : User.fromJson(json['created_by'] as Map<String, dynamic>),
     createdAt: json['created_at'] as int?,
     data: json['data'] as String?,
     customType: json['custom_type'] as String?,
@@ -32,7 +32,7 @@ Map<String, dynamic> _$OpenChannelToJson(OpenChannel instance) =>
       'channel_url': instance.channelUrl,
       'name': instance.name,
       'cover_url': instance.coverUrl,
-      'creator': instance.creator?.toJson(),
+      'created_by': instance.creator?.toJson(),
       'created_at': instance.createdAt,
       'data': instance.data,
       'custom_type': instance.customType,


### PR DESCRIPTION
`BaseChannel.creator` always returns `null` because it is incorrectly looking at `json['creator']` when it should be looking at `json['created_by']`

